### PR TITLE
Depend on epoxy alone

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -97,7 +97,7 @@ let package = Package(
             name: "RAKEpoxy",
             dependencies: [
                 "RAKConfig",
-                .product(name: "EpoxyCollectionView", package: "epoxy-ios"),
+                .product(name: "Epoxy", package: "epoxy-ios"),
             ],
             path: "Sources/Epoxy"),
         

--- a/Package.swift
+++ b/Package.swift
@@ -38,7 +38,6 @@ let package = Package(
                 "RAKConfig",
                 "RAKCore",
                 "RAKEncrypte",
-                "RAKEpoxy",
                 "RAKGradient",
                 "RAKLocalCache",
                 "RAKNotification",

--- a/Sources/RakuyoKit/Exports.swift
+++ b/Sources/RakuyoKit/Exports.swift
@@ -4,7 +4,6 @@
 @_exported import RAKConfig
 @_exported import RAKCore
 @_exported import RAKEncrypte
-@_exported import RAKEpoxy
 @_exported import RAKGradient
 @_exported import RAKLocalCache
 @_exported import RAKNotification


### PR DESCRIPTION
If you want to use it, you need to introduce it separately

Additionally, `RAKEpoxy` changes to rely on the complete `Epoxy` component